### PR TITLE
Fix tests to run everywhere

### DIFF
--- a/test/lib/test_rw.js
+++ b/test/lib/test_rw.js
@@ -23,7 +23,7 @@
 var color = require('ansi-color').set;
 var hex = require('hexer');
 var util = require('util');
-var bufrw = require('bufrw');
+var bufrw = require('../../index');
 
 module.exports.cases = testCases;
 


### PR DESCRIPTION
Turns out I had a require that only worked locally due to having bufrw `npm link`ed.