### PR TITLE
FixedWidth: check for fields during serialization

### DIFF
--- a/fixed_width_rw.js
+++ b/fixed_width_rw.js
@@ -76,7 +76,7 @@ FixedWidthRW.prototype.readFrom = function readFrom(buffer, offset) {
     if (end > buffer.length) {
         return ReadResult.shortError(self.length, buffer.length - offset, offset);
     } else {
-        var res = ReadResult.just(end, buffer.slice(offset, end)); 
+        var res = ReadResult.just(end, buffer.slice(offset, end));
         return res;
     }
 };

--- a/test/struct_rw.js
+++ b/test/struct_rw.js
@@ -23,6 +23,7 @@
 var testRW = require('../test_rw');
 var test = require('tape');
 
+var bufrw = require('../');
 var LengthResult = require('../base').LengthResult;
 var ReadResult = require('../base').ReadResult;
 var WriteResult = require('../base').WriteResult;
@@ -132,6 +133,46 @@ test('StructRW: frame', testRW.cases(Frame.rw, [
             bytes: [0x00, 0x00, 0x00, 0xff],
             error: {
                 message: 'frame data past message'
+            }
+        }
+    }
+]));
+
+
+function Thing(foo, bar) {
+    if (!(this instanceof Thing)) return new Thing(foo, bar);
+    var self = this;
+    self.foo = foo;
+    self.bar = bar;
+}
+
+Thing.RW = bufrw.Struct(Thing, {
+    foo: bufrw.UInt8,
+    bar: bufrw.UInt8,
+    baz: bufrw.FixedWidth(8)
+});
+
+test('StructRW: writing with invalid field', testRW.cases(Thing.RW, [
+    {
+        lengthTest: {
+            value: Thing(8, 9),
+            error: {
+                name: 'MissingFieldError',
+                type: 'missing.field',
+                message: 'missing field baz on Thing',
+                struct: 'Thing',
+                field: 'baz'
+            }
+        },
+        writeTest: {
+            value: Thing(8, 9),
+            length: 10,
+            error: {
+                name: 'MissingFieldError',
+                type: 'missing.field',
+                message: 'missing field baz on Thing',
+                struct: 'Thing',
+                field: 'baz'
             }
         }
     }


### PR DESCRIPTION
Noticed that when attempting to serialize a struct with a `FixedWidth` and that `FixedWidth` wasn't specified in the object we'd get a garbage exception. This adds in a check to make sure fields that are named are actually specified in the object, so we don't try to get the byte length of something undefined, nor do we attempt to serialize something that's undefined.