### PR TITLE
Result: bring inline with l/r/w result shapes

### DIFF
--- a/result.js
+++ b/result.js
@@ -20,16 +20,16 @@
 
 module.exports = Result;
 
-function Result(error, value) {
+function Result(err, value) {
     var self = this;
+    self.err = err || null;
     self.value = value;
-    self.error = error || null;
 }
 
 Result.prototype.toValue = function toValue() {
     var self = this;
-    if (self.error) {
-        throw self.error;
+    if (self.err) {
+        throw self.err;
     } else {
         return self.value;
     }
@@ -38,12 +38,12 @@ Result.prototype.toValue = function toValue() {
 /* istanbul ignore next */
 Result.prototype.toCallback = function toCallback(callback) {
     var self = this;
-    callback(self.error, self.value);
+    callback(self.err, self.value);
 };
 
 // XXX to be phased out of use in favor of using Result return values.
 /* istanbul ignore next */
 Result.prototype.toTuple = function toTuple() {
     var self = this;
-    return [self.error, self.value];
+    return [self.err, self.value];
 };

--- a/stream/chunk_writer.js
+++ b/stream/chunk_writer.js
@@ -54,7 +54,7 @@ inherits(ChunkWriter, Transform);
 ChunkWriter.prototype._transform = function _transform(value, encoding, callback) {
     var self = this;
     var res = toBufferResult(self.chunkRW, value);
-    var err = res.error;
+    var err = res.err;
     var buffer = res.value;
     if (err) {
         callback(ChunkWriteError(err, {

--- a/test_rw.js
+++ b/test_rw.js
@@ -106,7 +106,7 @@ RWTestCase.prototype.runWriteTest = function runWriteTest() {
     var got = Buffer(testCase.bytes ? testCase.bytes.length : testCase.length || 0);
     got.fill(0);
     var res = intoBufferResult(self.rw, got, val);
-    var err = res.error;
+    var err = res.err;
     if (err) {
         if (testCase.error) {
             self.assert.deepEqual(
@@ -139,7 +139,7 @@ RWTestCase.prototype.runReadTest = function runReadTest() {
     var buffer = Buffer(testCase.bytes);
     buffer = new AnnotatedBuffer(buffer);
     var res = fromBufferResult(self.rw, buffer);
-    var err = res.error;
+    var err = res.err;
     var got = res.value;
     if (err) {
         if (testCase.error) {


### PR DESCRIPTION
This will be a breaking change for thrift(ify,rw) but hopefully there's still time to save sanity.

r @kriskowal 