### PR TITLE
Add fast utf8 string path

### DIFF
--- a/string_rw.js
+++ b/string_rw.js
@@ -34,6 +34,11 @@ function StringRW(sizerw, encoding) {
     }
     var self = this;
     self.encoding = encoding || 'utf8';
+    // istanbul ignore else
+    if (self.encoding === 'utf8') {
+        self.writeInto = self.writeUtf8Into;
+        self.readFrom = self.readUtf8From;
+    }
     VariableBufferRW.call(self, sizerw);
 }
 inherits(StringRW, VariableBufferRW);
@@ -51,6 +56,7 @@ StringRW.prototype.byteLength = function byteLength(str) {
     return new LengthResult(null, len.length + length);
 };
 
+// istanbul ignore next
 StringRW.prototype.writeInto = function writeInto(str, buffer, offset) {
     var self = this;
     var start = offset + self.sizerw.width;
@@ -65,6 +71,26 @@ StringRW.prototype.writeInto = function writeInto(str, buffer, offset) {
     return new WriteResult(null, start + length);
 };
 
+StringRW.prototype.writeUtf8Into = function writeInto(str, buffer, offset) {
+    var self = this;
+    var start = offset + self.sizerw.width;
+    var length = 0;
+    if (typeof str === 'string') {
+        // istanbul ignore else
+        if (buffer.parent) {
+            length = buffer.parent.utf8Write(str, buffer.offset + start, buffer.length - start);
+        } else {
+            length = buffer.write(str, start, self.encoding);
+        }
+    } else if (str !== null && str !== undefined) {
+        return WriteResult.error(errors.expected(str, 'string, null, or undefined'), offset);
+    }
+    var res = self.sizerw.writeInto(length, buffer, offset);
+    if (res.err) return res;
+    return new WriteResult(null, start + length);
+};
+
+// istanbul ignore next
 StringRW.prototype.readFrom = function readFrom(buffer, offset) {
     var self = this;
     var res = self.sizerw.readFrom(buffer, offset);
@@ -77,6 +103,27 @@ StringRW.prototype.readFrom = function readFrom(buffer, offset) {
         offset = res.offset;
         var end = offset + length;
         var str = buffer.toString(self.encoding, offset, end);
+        return new ReadResult(null, end, str);
+    }
+};
+
+StringRW.prototype.readUtf8From = function readFrom(buffer, offset) {
+    var self = this;
+    var res = self.sizerw.readFrom(buffer, offset);
+    if (res.err) return res;
+    var length = res.value;
+    var remain = buffer.length - res.offset;
+    if (remain < length) {
+        return ReadResult.shortError(length, remain, offset, res.offset);
+    } else {
+        offset = res.offset;
+        var end = offset + length;
+        var str = '';
+        if (buffer.parent) {
+            str = buffer.parent.utf8Slice(buffer.offset + offset, buffer.offset + end);
+        } else {
+            str = buffer.toString(self.encoding, offset, end);
+        }
         return new ReadResult(null, end, str);
     }
 };


### PR DESCRIPTION
This ends up being a >5% boost for TChannel.

Turns out that Buffer#write and Buffer#toString do a crazy amount of overhead, including such gems as `encoding = String(encoding || 'utf8').toLowerCase();`, in addition of course to a switch on encoding.

cc @Raynos @kriskowal 