### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/annotated_buffer.js
+++ b/annotated_buffer.js
@@ -88,8 +88,8 @@ AnnotatedBuffer.prototype.slice = function slice(start, end) {
 // -- atom readers
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readInt8 = function readInt8(offset, noAssert) {
-    var value = this.buffer.readInt8(offset, noAssert);
+AnnotatedBuffer.prototype.readInt8 = function readInt8(offset) {
+    var value = this.buffer.readInt8(offset);
     this.annotations.push({
         kind: 'read',
         name: 'Int8',
@@ -100,8 +100,8 @@ AnnotatedBuffer.prototype.readInt8 = function readInt8(offset, noAssert) {
     return value;
 };
 
-AnnotatedBuffer.prototype.readUInt8 = function readUInt8(offset, noAssert) {
-    var value = this.buffer.readUInt8(offset, noAssert);
+AnnotatedBuffer.prototype.readUInt8 = function readUInt8(offset) {
+    var value = this.buffer.readUInt8(offset);
     this.annotations.push({
         kind: 'read',
         name: 'UInt8',
@@ -113,8 +113,8 @@ AnnotatedBuffer.prototype.readUInt8 = function readUInt8(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
-    var value = this.buffer.readUInt16LE(offset, noAssert);
+AnnotatedBuffer.prototype.readUInt16LE = function readUInt16LE(offset) {
+    var value = this.buffer.readUInt16LE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'UInt16LE',
@@ -125,8 +125,8 @@ AnnotatedBuffer.prototype.readUInt16LE = function readUInt16LE(offset, noAssert)
     return value;
 };
 
-AnnotatedBuffer.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
-    var value = this.buffer.readUInt16BE(offset, noAssert);
+AnnotatedBuffer.prototype.readUInt16BE = function readUInt16BE(offset) {
+    var value = this.buffer.readUInt16BE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'UInt16BE',
@@ -138,8 +138,8 @@ AnnotatedBuffer.prototype.readUInt16BE = function readUInt16BE(offset, noAssert)
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
-    var value = this.buffer.readUInt32LE(offset, noAssert);
+AnnotatedBuffer.prototype.readUInt32LE = function readUInt32LE(offset) {
+    var value = this.buffer.readUInt32LE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'UInt32LE',
@@ -151,8 +151,8 @@ AnnotatedBuffer.prototype.readUInt32LE = function readUInt32LE(offset, noAssert)
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
-    var value = this.buffer.readUInt32BE(offset, noAssert);
+AnnotatedBuffer.prototype.readUInt32BE = function readUInt32BE(offset) {
+    var value = this.buffer.readUInt32BE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'UInt32BE',
@@ -164,8 +164,8 @@ AnnotatedBuffer.prototype.readUInt32BE = function readUInt32BE(offset, noAssert)
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
-    var value = this.buffer.readInt16LE(offset, noAssert);
+AnnotatedBuffer.prototype.readInt16LE = function readInt16LE(offset) {
+    var value = this.buffer.readInt16LE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'Int16LE',
@@ -177,8 +177,8 @@ AnnotatedBuffer.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
-    var value = this.buffer.readInt16BE(offset, noAssert);
+AnnotatedBuffer.prototype.readInt16BE = function readInt16BE(offset) {
+    var value = this.buffer.readInt16BE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'Int16BE',
@@ -190,8 +190,8 @@ AnnotatedBuffer.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
-    var value = this.buffer.readInt32LE(offset, noAssert);
+AnnotatedBuffer.prototype.readInt32LE = function readInt32LE(offset) {
+    var value = this.buffer.readInt32LE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'Int32LE',
@@ -203,8 +203,8 @@ AnnotatedBuffer.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
-    var value = this.buffer.readInt32BE(offset, noAssert);
+AnnotatedBuffer.prototype.readInt32BE = function readInt32BE(offset) {
+    var value = this.buffer.readInt32BE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'Int32BE',
@@ -216,8 +216,8 @@ AnnotatedBuffer.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
-    var value = this.buffer.readFloatLE(offset, noAssert);
+AnnotatedBuffer.prototype.readFloatLE = function readFloatLE(offset) {
+    var value = this.buffer.readFloatLE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'FloatLE',
@@ -229,8 +229,8 @@ AnnotatedBuffer.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
-    var value = this.buffer.readFloatBE(offset, noAssert);
+AnnotatedBuffer.prototype.readFloatBE = function readFloatBE(offset) {
+    var value = this.buffer.readFloatBE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'FloatBE',
@@ -242,8 +242,8 @@ AnnotatedBuffer.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
-    var value = this.buffer.readDoubleLE(offset, noAssert);
+AnnotatedBuffer.prototype.readDoubleLE = function readDoubleLE(offset) {
+    var value = this.buffer.readDoubleLE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'DoubleLE',
@@ -255,8 +255,8 @@ AnnotatedBuffer.prototype.readDoubleLE = function readDoubleLE(offset, noAssert)
 };
 
 // istanbul ignore next
-AnnotatedBuffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
-    var value = this.buffer.readDoubleBE(offset, noAssert);
+AnnotatedBuffer.prototype.readDoubleBE = function readDoubleBE(offset) {
+    var value = this.buffer.readDoubleBE(offset);
     this.annotations.push({
         kind: 'read',
         name: 'DoubleBE',

--- a/atoms.js
+++ b/atoms.js
@@ -88,107 +88,107 @@ IntegerRW.prototype.poolWriteInto = function poolWriteInto(destResult, value, bu
 
 var Int8 = IntegerRW(1, -0x80, 0x7f,
     function readInt8From(destResult, buffer, offset) {
-        var value = buffer.readInt8(offset, true);
+        var value = buffer.readInt8(offset);
         return destResult.reset(null, offset + 1, value);
     },
     function writeInt8Into(destResult, value, buffer, offset) {
-        buffer.writeInt8(value, offset, true);
+        buffer.writeInt8(value, offset);
         return destResult.reset(null, offset + 1);
     });
 
 var Int16BE = IntegerRW(2, -0x8000, 0x7fff,
     function readInt16BEFrom(destResult, buffer, offset) {
-        var value = buffer.readInt16BE(offset, true);
+        var value = buffer.readInt16BE(offset);
         return destResult.reset(null, offset + 2, value);
     },
     function writeInt16BEInto(destResult, value, buffer, offset) {
-        buffer.writeInt16BE(value, offset, true);
+        buffer.writeInt16BE(value, offset);
         return destResult.reset(null, offset + 2);
     });
 
 var Int32BE = IntegerRW(4, -0x80000000, 0x7fffffff,
     function readInt32BEFrom(destResult, buffer, offset) {
-        var value = buffer.readInt32BE(offset, true);
+        var value = buffer.readInt32BE(offset);
         return destResult.reset(null, offset + 4, value);
     },
     function writeInt32BEInto(destResult, value, buffer, offset) {
-        buffer.writeInt32BE(value, offset, true);
+        buffer.writeInt32BE(value, offset);
         return destResult.reset(null, offset + 4);
     });
 
 var Int16LE = IntegerRW(2, -0x8000, 0x7fff,
     function readInt16LEFrom(destResult, buffer, offset) {
-        var value = buffer.readInt16LE(offset, true);
+        var value = buffer.readInt16LE(offset);
         return destResult.reset(null, offset + 2, value);
     },
     function writeInt16LEInto(destResult, value, buffer, offset) {
-        buffer.writeInt16LE(value, offset, true);
+        buffer.writeInt16LE(value, offset);
         return destResult.reset(null, offset + 2);
     });
 
 var Int32LE = IntegerRW(4, -0x80000000, 0x7fffffff,
     function readInt32LEFrom(destResult, buffer, offset) {
-        var value = buffer.readInt32LE(offset, true);
+        var value = buffer.readInt32LE(offset);
         return destResult.reset(null, offset + 4, value);
     },
     function writeInt32LEInto(destResult, value, buffer, offset) {
-        buffer.writeInt32LE(value, offset, true);
+        buffer.writeInt32LE(value, offset);
         return destResult.reset(null, offset + 4);
     });
 
 var UInt8 = IntegerRW(1, 0, 0xff,
     function readUInt8From(destResult, buffer, offset) {
-        var value = buffer.readUInt8(offset, true);
+        var value = buffer.readUInt8(offset);
         return destResult.reset(null, offset + 1, value);
     },
     function writeUInt8Into(destResult, value, buffer, offset) {
-        buffer.writeUInt8(value, offset, true);
+        buffer.writeUInt8(value, offset);
         return destResult.reset(null, offset + 1);
     });
 
 var UInt16BE = IntegerRW(2, 0, 0xffff,
     function readUInt16BEFrom(destResult, buffer, offset) {
-        var value = buffer.readUInt16BE(offset, true);
+        var value = buffer.readUInt16BE(offset);
         return destResult.reset(null, offset + 2, value);
     },
     function writeUInt16BEInto(destResult, value, buffer, offset) {
-        buffer.writeUInt16BE(value, offset, true);
+        buffer.writeUInt16BE(value, offset);
         return destResult.reset(null, offset + 2);
     });
 
 var UInt32BE = IntegerRW(4, 0, 0xffffffff,
     function readUInt32BEFrom(destResult, buffer, offset) {
-        var value = buffer.readUInt32BE(offset, true);
+        var value = buffer.readUInt32BE(offset);
         return destResult.reset(null, offset + 4, value);
     },
     function writeUInt32BEInto(destResult, value, buffer, offset) {
-        buffer.writeUInt32BE(value, offset, true);
+        buffer.writeUInt32BE(value, offset);
         return destResult.reset(null, offset + 4);
     });
 
 var UInt16LE = IntegerRW(2, 0, 0xffff,
     function readUInt16LEFrom(destResult, buffer, offset) {
-        var value = buffer.readUInt16LE(offset, true);
+        var value = buffer.readUInt16LE(offset);
         return destResult.reset(null, offset + 2, value);
     },
     function writeUInt16LEInto(destResult, value, buffer, offset) {
-        buffer.writeUInt16LE(value, offset, true);
+        buffer.writeUInt16LE(value, offset);
         return destResult.reset(null, offset + 2);
     });
 
 var UInt32LE = IntegerRW(4, 0, 0xffffffff,
     function readUInt32LEFrom(destResult, buffer, offset) {
-        var value = buffer.readUInt32LE(offset, true);
+        var value = buffer.readUInt32LE(offset);
         return destResult.reset(null, offset + 4, value);
     },
     function writeUInt32LEInto(destResult, value, buffer, offset) {
-        buffer.writeUInt32LE(value, offset, true);
+        buffer.writeUInt32LE(value, offset);
         return destResult.reset(null, offset + 4);
     });
 
 var FloatLE = AtomRW(4,
     function readFloatLEFrom(destResult, buffer, offset) {
-        var value = buffer.readFloatLE(offset, true);
+        var value = buffer.readFloatLE(offset);
         return destResult.reset(null, offset + 4, value);
     },
     function writeFloatLEInto(destResult, value, buffer, offset) {
@@ -203,7 +203,7 @@ var FloatLE = AtomRW(4,
 
 var FloatBE = AtomRW(4,
     function readFloatBEFrom(destResult, buffer, offset) {
-        var value = buffer.readFloatBE(offset, true);
+        var value = buffer.readFloatBE(offset);
         return destResult.reset(null, offset + 4, value);
     },
     function writeFloatBEInto(destResult, value, buffer, offset) {
@@ -218,7 +218,7 @@ var FloatBE = AtomRW(4,
 
 var DoubleLE = AtomRW(8,
     function readDoubleLEFrom(destResult, buffer, offset) {
-        var value = buffer.readDoubleLE(offset, true);
+        var value = buffer.readDoubleLE(offset);
         return destResult.reset(null, offset + 8, value);
     },
     function writeDoubleLEInto(destResult, value, buffer, offset) {
@@ -233,7 +233,7 @@ var DoubleLE = AtomRW(8,
 
 var DoubleBE = AtomRW(8,
     function readDoubleBEFrom(destResult, buffer, offset) {
-        var value = buffer.readDoubleBE(offset, true);
+        var value = buffer.readDoubleBE(offset);
         return destResult.reset(null, offset + 8, value);
     },
     function writeDoubleBEInto(destResult, value, buffer, offset) {

--- a/stream/concat_read_buffer.js
+++ b/stream/concat_read_buffer.js
@@ -65,18 +65,18 @@ ConcatReadBuffer.prototype.shift = function shift(n) {
 
 
 // istanbul ignore next
-ConcatReadBuffer.prototype.readUInt8 = function readUInt8(offset, noAssert) {
-    return this.buffer.readUInt8(offset, noAssert);
+ConcatReadBuffer.prototype.readUInt8 = function readUInt8(offset) {
+    return this.buffer.readUInt8(offset);
 };
 
 // istanbul ignore next
-ConcatReadBuffer.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
-    return this.buffer.readUInt16BE(offset, noAssert);
+ConcatReadBuffer.prototype.readUInt16BE = function readUInt16BE(offset) {
+    return this.buffer.readUInt16BE(offset);
 };
 
 // istanbul ignore next
-ConcatReadBuffer.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
-    return this.buffer.readUInt32BE(offset, noAssert);
+ConcatReadBuffer.prototype.readUInt32BE = function readUInt32BE(offset) {
+    return this.buffer.readUInt32BE(offset);
 };
 
 // TODO: complete Buffer API aping

--- a/varint.js
+++ b/varint.js
@@ -64,7 +64,7 @@ function writeUnsignedVarIntInto(destResult, n, buffer, offset) {
         var b = n & 0x7f;
         n >>= 7;
         if (offset !== end) b |= 0x80;
-        buffer.writeUInt8(b, --offset, true);
+        buffer.writeUInt8(b, --offset);
         if (n <= 0) break;
     }
 
@@ -75,7 +75,7 @@ function readUnsignedVarIntFrom(destResult, buffer, offset) {
     var start = offset;
     var n = 0;
     while (offset < buffer.length) {
-        var b = buffer.readUInt8(offset++, true);
+        var b = buffer.readUInt8(offset++);
         if (n !== 0) n <<= 7;
         n += b & 0x7f;
         if (!(b & 0x80)) {


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395

Please note: two parts of a test are failing and I am unsure what the best thing would be to do. I personally feel like it might be best to just remove them.