### PR TITLE
Do not upgrade npm in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
-before_install: npm i npm@latest -g
 script: npm run travis


### PR DESCRIPTION
This change fixes the build. We have always upgraded npm as an initial step in CI. I believe this previously addressed a bug in the default version installed with node 0.10. However, now it brings in a version of npm that requires syntax introduced to JavaScript, oh, some years ago, which does not work in Node.js 0.10. We must continue testing in this version for…backward compatibility reasons.