### PR TITLE
Address deprecation of Buffer constructor forms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
+  - "12"
 script: npm run travis

--- a/interface.js
+++ b/interface.js
@@ -29,6 +29,10 @@ var errors = require('./errors');
 var AnnotatedBuffer = require('./annotated_buffer');
 var errorHighlighter = require('./error_highlighter');
 
+// Node.js deprecated Buffer(length) in favor of Buffer.alloc(length).
+// istanbul ignore next
+var bufferAlloc = Buffer.alloc || Buffer;
+
 function makeAnnotatedBuffer(buffer, start, clear) {
     // istanbul ignore if
     if (start > 0) buffer = buffer.slice(start);
@@ -51,7 +55,7 @@ function annotateError(res1, res2, start, annBuf) {
     }
 }
 
-var emptyBuffer = Buffer(0);
+var emptyBuffer = bufferAlloc(0);
 
 function fromBuffer(rw, buffer, offset) {
     return fromBufferResult(rw, buffer, offset).toValue();
@@ -133,7 +137,7 @@ function toBufferResult(rw, value) {
     var lenRes = rw.byteLength(value);
     if (lenRes.err) return new Result(lenRes.err, emptyBuffer);
     var length = lenRes.length;
-    var buffer = new Buffer(length);
+    var buffer = bufferAlloc(length);
     // buffer.fill(0); TODO option
     return intoBufferResult(rw, buffer, value);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1561 @@
+{
+  "name": "bufrw",
+  "version": "1.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://unpm.uberinternal.com/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://unpm.uberinternal.com/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
+    },
+    "ansi-color": {
+      "version": "0.2.1",
+      "resolved": "https://unpm.uberinternal.com/ansi-color/-/ansi-color-0.2.1.tgz",
+      "integrity": "sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://unpm.uberinternal.com/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://unpm.uberinternal.com/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://unpm.uberinternal.com/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://unpm.uberinternal.com/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://unpm.uberinternal.com/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.9.0",
+      "resolved": "https://unpm.uberinternal.com/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha1-JDkOatYThrCnRyZXVNKhchnehiw=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://unpm.uberinternal.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://unpm.uberinternal.com/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://unpm.uberinternal.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://unpm.uberinternal.com/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://unpm.uberinternal.com/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://unpm.uberinternal.com/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://unpm.uberinternal.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://unpm.uberinternal.com/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://unpm.uberinternal.com/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://unpm.uberinternal.com/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://unpm.uberinternal.com/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "coveralls": {
+      "version": "2.13.3",
+      "resolved": "https://unpm.uberinternal.com/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha1-mtfCrlJ0F/Nh6LYmSD9I7pLdK8c=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://unpm.uberinternal.com/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://unpm.uberinternal.com/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://unpm.uberinternal.com/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://unpm.uberinternal.com/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://unpm.uberinternal.com/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://unpm.uberinternal.com/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://unpm.uberinternal.com/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://unpm.uberinternal.com/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0=",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://unpm.uberinternal.com/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://unpm.uberinternal.com/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://unpm.uberinternal.com/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://unpm.uberinternal.com/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://unpm.uberinternal.com/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://unpm.uberinternal.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "error": {
+      "version": "7.2.1",
+      "resolved": "https://unpm.uberinternal.com/error/-/error-7.2.1.tgz",
+      "integrity": "sha1-6rIaRom19oT8g9qEoOOQ3oLZSJQ=",
+      "requires": {
+        "string-template": "~0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://unpm.uberinternal.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.7.1",
+      "resolved": "https://unpm.uberinternal.com/escodegen/-/escodegen-1.7.1.tgz",
+      "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
+      "dev": true,
+      "requires": {
+        "esprima": "^1.2.2",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.5.0",
+        "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.5",
+          "resolved": "https://unpm.uberinternal.com/esprima/-/esprima-1.2.5.tgz",
+          "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://unpm.uberinternal.com/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://unpm.uberinternal.com/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://unpm.uberinternal.com/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://unpm.uberinternal.com/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://unpm.uberinternal.com/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://unpm.uberinternal.com/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "resolved": "https://unpm.uberinternal.com/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+      "dev": true
+    },
+    "faucet": {
+      "version": "0.0.1",
+      "resolved": "https://unpm.uberinternal.com/faucet/-/faucet-0.0.1.tgz",
+      "integrity": "sha1-WX3PHSGJosBiMhtZHo8VHtIDnZw=",
+      "dev": true,
+      "requires": {
+        "defined": "0.0.0",
+        "duplexer": "~0.1.1",
+        "minimist": "0.0.5",
+        "sprintf": "~0.1.3",
+        "tap-parser": "~0.4.0",
+        "tape": "~2.3.2",
+        "through2": "~0.2.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+          "dev": true
+        },
+        "tape": {
+          "version": "2.3.3",
+          "resolved": "https://unpm.uberinternal.com/tape/-/tape-2.3.3.tgz",
+          "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+          "dev": true,
+          "requires": {
+            "deep-equal": "~0.1.0",
+            "defined": "~0.0.0",
+            "inherits": "~2.0.1",
+            "jsonify": "~0.0.0",
+            "resumer": "~0.0.0",
+            "through": "~2.3.4"
+          }
+        }
+      }
+    },
+    "fileset": {
+      "version": "0.2.1",
+      "resolved": "https://unpm.uberinternal.com/fileset/-/fileset-0.2.1.tgz",
+      "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+      "dev": true,
+      "requires": {
+        "glob": "5.x",
+        "minimatch": "2.x"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://unpm.uberinternal.com/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://unpm.uberinternal.com/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://unpm.uberinternal.com/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://unpm.uberinternal.com/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://unpm.uberinternal.com/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://unpm.uberinternal.com/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://unpm.uberinternal.com/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.5.3",
+      "resolved": "https://unpm.uberinternal.com/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha1-XPdb2HFPdgVxNRGla+fDSb7LBII=",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://unpm.uberinternal.com/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://unpm.uberinternal.com/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://unpm.uberinternal.com/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://unpm.uberinternal.com/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "hexer": {
+      "version": "1.5.0",
+      "resolved": "https://unpm.uberinternal.com/hexer/-/hexer-1.5.0.tgz",
+      "integrity": "sha1-uGzoCFmOip0YksVx887dhvyfBlM=",
+      "requires": {
+        "ansi-color": "^0.2.1",
+        "minimist": "^1.1.0",
+        "process": "^0.10.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://unpm.uberinternal.com/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "home-path": {
+      "version": "0.1.2",
+      "resolved": "https://unpm.uberinternal.com/home-path/-/home-path-0.1.2.tgz",
+      "integrity": "sha1-PbJsojrcFE/uqPHi18j2yJDL/io=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://unpm.uberinternal.com/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://unpm.uberinternal.com/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://unpm.uberinternal.com/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.20.0",
+      "resolved": "https://unpm.uberinternal.com/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+      "integrity": "sha1-E0Wm/KPo2u/BDQ+ncGf1TO2v1Zo=",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://unpm.uberinternal.com/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://unpm.uberinternal.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://unpm.uberinternal.com/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul": {
+      "version": "0.3.22",
+      "resolved": "https://unpm.uberinternal.com/istanbul/-/istanbul-0.3.22.tgz",
+      "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.7.x",
+        "esprima": "2.5.x",
+        "fileset": "0.2.x",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.5.0",
+          "resolved": "https://unpm.uberinternal.com/esprima/-/esprima-2.5.0.tgz",
+          "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "itape": {
+      "version": "1.9.2",
+      "resolved": "https://unpm.uberinternal.com/itape/-/itape-1.9.2.tgz",
+      "integrity": "sha1-GBeSnn95KZHffk42gc7nDGzcpD0=",
+      "dev": true,
+      "requires": {
+        "home-path": "^0.1.1",
+        "minimist": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "parents": "^1.0.0",
+        "process": "^0.10.0",
+        "readable-stream": "^1.0.33",
+        "resolve": "^1.0.0",
+        "tap-out": "git://github.com/Raynos/tap-out.git#support-stack",
+        "xtend": "^4.0.0"
+      }
+    },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://unpm.uberinternal.com/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://unpm.uberinternal.com/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jshint": {
+      "version": "2.10.3",
+      "resolved": "https://unpm.uberinternal.com/jshint/-/jshint-2.10.3.tgz",
+      "integrity": "sha1-mNx2W/aSC0G8Jxn3a4c51vbpOpw=",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.11",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://unpm.uberinternal.com/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://unpm.uberinternal.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://unpm.uberinternal.com/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://unpm.uberinternal.com/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://unpm.uberinternal.com/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://unpm.uberinternal.com/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.2.5",
+      "resolved": "https://unpm.uberinternal.com/levn/-/levn-0.2.5.tgz",
+      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.0",
+        "type-check": "~0.3.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://unpm.uberinternal.com/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://unpm.uberinternal.com/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://unpm.uberinternal.com/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.42.0",
+      "resolved": "https://unpm.uberinternal.com/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha1-PiUpB7THrbkGWXtLZWNics+ee6w=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.25",
+      "resolved": "https://unpm.uberinternal.com/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha1-OXctRmIfk+KoCoVsU7hqYhVqZDc=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.42.0"
+      }
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://unpm.uberinternal.com/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://unpm.uberinternal.com/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://unpm.uberinternal.com/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://unpm.uberinternal.com/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "0.4.0",
+      "resolved": "https://unpm.uberinternal.com/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://unpm.uberinternal.com/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opn": {
+      "version": "1.0.2",
+      "resolved": "https://unpm.uberinternal.com/opn/-/opn-1.0.2.tgz",
+      "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://unpm.uberinternal.com/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.5.0",
+      "resolved": "https://unpm.uberinternal.com/optionator/-/optionator-0.5.0.tgz",
+      "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.2",
+        "fast-levenshtein": "~1.0.0",
+        "levn": "~0.2.5",
+        "prelude-ls": "~1.1.1",
+        "type-check": "~0.3.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "parents": {
+      "version": "1.0.1",
+      "resolved": "https://unpm.uberinternal.com/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "dev": true,
+      "requires": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://unpm.uberinternal.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://unpm.uberinternal.com/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://unpm.uberinternal.com/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://unpm.uberinternal.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pre-commit": {
+      "version": "0.0.9",
+      "resolved": "https://unpm.uberinternal.com/pre-commit/-/pre-commit-0.0.9.tgz",
+      "integrity": "sha1-uOjikwwONViur6G4lwYgPXcrl8s=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://unpm.uberinternal.com/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process": {
+      "version": "0.10.1",
+      "resolved": "https://unpm.uberinternal.com/process/-/process-0.10.1.tgz",
+      "integrity": "sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://unpm.uberinternal.com/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://unpm.uberinternal.com/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "re-emitter": {
+      "version": "1.1.4",
+      "resolved": "https://unpm.uberinternal.com/re-emitter/-/re-emitter-1.1.4.tgz",
+      "integrity": "sha1-Fb3vyj1H4F1kQoOP0mdZyKTqojY=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "readdirp": {
+      "version": "1.4.0",
+      "resolved": "https://unpm.uberinternal.com/readdirp/-/readdirp-1.4.0.tgz",
+      "integrity": "sha1-xd5vyz3sgFI8HHARPxoZDYr4LIk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~4.1.2",
+        "minimatch": "~0.2.12",
+        "readable-stream": "~1.0.26-2"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://unpm.uberinternal.com/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1",
+        "uuid": "^3.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://unpm.uberinternal.com/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://unpm.uberinternal.com/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://unpm.uberinternal.com/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://unpm.uberinternal.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://unpm.uberinternal.com/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://unpm.uberinternal.com/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://unpm.uberinternal.com/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://unpm.uberinternal.com/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://unpm.uberinternal.com/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://unpm.uberinternal.com/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://unpm.uberinternal.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://unpm.uberinternal.com/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://unpm.uberinternal.com/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://unpm.uberinternal.com/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://unpm.uberinternal.com/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://unpm.uberinternal.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tap-out": {
+      "version": "git://github.com/Raynos/tap-out.git#ba074212dd3da3319e07b4a32807bdd720308a4b",
+      "from": "git://github.com/Raynos/tap-out.git#support-stack",
+      "dev": true,
+      "requires": {
+        "re-emitter": "^1.0.0",
+        "split": "^0.3.1",
+        "through2": "^0.6.3",
+        "trim": "0.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://unpm.uberinternal.com/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
+      }
+    },
+    "tap-parser": {
+      "version": "0.4.3",
+      "resolved": "https://unpm.uberinternal.com/tap-parser/-/tap-parser-0.4.3.tgz",
+      "integrity": "sha1-pOrhkMENdsehEZIf84u+TVjwnuo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.11"
+      }
+    },
+    "tape": {
+      "version": "3.6.1",
+      "resolved": "https://unpm.uberinternal.com/tape/-/tape-3.6.1.tgz",
+      "integrity": "sha1-SJPdU+KApfWMDOswwsDrs7zVHh8=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~0.2.0",
+        "defined": "~0.0.0",
+        "glob": "~3.2.9",
+        "inherits": "~2.0.1",
+        "object-inspect": "~0.4.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://unpm.uberinternal.com/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://unpm.uberinternal.com/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        }
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://unpm.uberinternal.com/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "0.2.3",
+      "resolved": "https://unpm.uberinternal.com/through2/-/through2-0.2.3.tgz",
+      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.1.9",
+        "xtend": "~2.1.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://unpm.uberinternal.com/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://unpm.uberinternal.com/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://unpm.uberinternal.com/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://unpm.uberinternal.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://unpm.uberinternal.com/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://unpm.uberinternal.com/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uber-licence": {
+      "version": "1.5.6",
+      "resolved": "https://unpm.uberinternal.com/uber-licence/-/uber-licence-1.5.6.tgz",
+      "integrity": "sha1-DmkL4y4qZXvVFv/Nl0fIbM6/FmQ=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.1.0",
+        "process": "^0.10.0",
+        "readdirp": "^1.3.0",
+        "run-parallel": "^1.0.0"
+      }
+    },
+    "uglify-js": {
+      "version": "3.7.3",
+      "resolved": "https://unpm.uberinternal.com/uglify-js/-/uglify-js-3.7.3.tgz",
+      "integrity": "sha1-+Rj86RgvRm1RQPJLsP81wtMtzGo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.3",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://unpm.uberinternal.com/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://unpm.uberinternal.com/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://unpm.uberinternal.com/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://unpm.uberinternal.com/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://unpm.uberinternal.com/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+    }
+  }
+}

--- a/test/fixed_width_rw.js
+++ b/test/fixed_width_rw.js
@@ -23,17 +23,19 @@
 var testRW = require('../test_rw');
 var test = require('tape');
 
+var bufferFrom = Buffer.from || Buffer;
+
 var FixedWidthRW = require('../fixed_width_rw');
 
 var fix8 = FixedWidthRW(8);
 var fixed8 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
 test('FixedWidthRW: simple fix:8', testRW.cases(fix8, [
-    [Buffer(fixed8), fixed8],
+    [bufferFrom(fixed8), fixed8],
 
     // mismatch errors
     {
         lengthTest: {
-            value: Buffer([0x01]),
+            value: bufferFrom([0x01]),
             error: {
                 type: 'bufrw.fixed-length-mismatch',
                 message: 'supplied length 1 mismatches fixed length 8',
@@ -42,7 +44,7 @@ test('FixedWidthRW: simple fix:8', testRW.cases(fix8, [
             }
         },
         writeTest: {
-            value: Buffer([0x01]),
+            value: bufferFrom([0x01]),
             error: {
                 type: 'bufrw.fixed-length-mismatch',
                 message: 'supplied length 1 mismatches fixed length 8',

--- a/test/interface.js
+++ b/test/interface.js
@@ -25,6 +25,9 @@ var test = require('tape');
 var iface = require('../interface');
 var BufferRW = require('../base').BufferRW;
 
+var bufferFrom = Buffer.from || Buffer;
+var bufferAlloc = Buffer.alloc || Buffer;
+
 var byteRW = {
     poolByteLength: function(destResult) {return destResult.reset(null, 1);},
     poolWriteInto: function(destResult, b, buffer, offset) {
@@ -71,7 +74,7 @@ test('byteLength', function t(assert) {
 test('toBuffer', function t(assert) {
     assert.deepEqual(
         iface.toBuffer(byteRW, 1),
-        Buffer([0x01]), 'write 1 uint8');
+        bufferFrom([0x01]), 'write 1 uint8');
     assert.throws(function() {
         iface.toBuffer(lengthErrorRW, 1);
     }, /boom/, 'length error throws');
@@ -83,26 +86,26 @@ test('toBuffer', function t(assert) {
 
 test('intoBuffer', function t(assert) {
     assert.deepEqual(
-        iface.intoBuffer(byteRW, Buffer([0]), 1),
-        Buffer([0x01]), 'write 1 uint8');
+        iface.intoBuffer(byteRW, bufferFrom([0]), 1),
+        bufferFrom([0x01]), 'write 1 uint8');
     assert.throws(function() {
-        iface.intoBuffer(writeErrorRW, Buffer([0]), 1);
+        iface.intoBuffer(writeErrorRW, bufferFrom([0]), 1);
     }, /bang/, 'write error throws');
     assert.throws(function() {
-        iface.intoBuffer(byteRW, Buffer([0, 0]), 1);
+        iface.intoBuffer(byteRW, bufferFrom([0, 0]), 1);
     }, /short write, 1 byte left over after writing 1/, 'short write error');
     assert.end();
 });
 
 test('fromBuffer', function t(assert) {
     assert.equal(
-        iface.fromBuffer(byteRW, Buffer([0x01])),
+        iface.fromBuffer(byteRW, bufferFrom([0x01])),
         1, 'read 1 uint8');
     assert.throws(function() {
-        iface.fromBuffer(readErrorRW, Buffer(0));
+        iface.fromBuffer(readErrorRW, bufferAlloc(0));
     }, /zot/, 'read error throws');
     assert.throws(function() {
-        iface.fromBuffer(byteRW, Buffer([0, 0]));
+        iface.fromBuffer(byteRW, bufferFrom([0, 0]));
     }, /short read, 1 byte left over after consuming 1/, 'short read error');
     assert.end();
 });

--- a/test/repeat_rw.js
+++ b/test/repeat_rw.js
@@ -29,6 +29,8 @@ var SeriesRW = require('../series');
 var ReadResult = require('../base').ReadResult;
 var StructRW = require('../struct');
 
+var bufferFrom = Buffer.from || Buffer;
+
 var brokenRW = {
     poolByteLength: function(destResult) {
         return destResult.reset(new Error('boom'));
@@ -124,7 +126,7 @@ test('RepeatRW: passes partrw error thru', testRW.cases(RepeatRW(atoms.UInt8, br
 
 test('RepeatRW: properly handles repeated array rws', function t(assert) {
     var thing = RepeatRW(atoms.UInt8, SeriesRW(atoms.UInt8, atoms.UInt8));
-    var buf = new Buffer([0x01, 0x02, 0x03]);
+    var buf = bufferFrom([0x01, 0x02, 0x03]);
 
     var readResult = new ReadResult();
     thing.poolReadFrom(readResult, buf, 0);
@@ -150,7 +152,7 @@ var consLoc = StructRW(Loc, {
 
 test('RepeatRW: properly handles repeated object rws', function t(assert) {
     var thing = RepeatRW(atoms.UInt8, consLoc);
-    var buf = new Buffer([0x01, 0x40, 0x42, 0xe3, 0x43, 0x7c, 0x56, 0x92, 0xb4,
+    var buf = bufferFrom([0x01, 0x40, 0x42, 0xe3, 0x43, 0x7c, 0x56, 0x92, 0xb4,
       0xc0, 0x5e, 0x9a, 0xb8, 0xa1, 0x9c, 0x9d, 0x5a]);
 
     var readResult = new ReadResult();

--- a/test/stream/chunk_writer.js
+++ b/test/stream/chunk_writer.js
@@ -33,6 +33,8 @@ var StringRW = require('../../string_rw');
 var SeriesRW = require('../../series');
 var BufferRW = require('../../base').BufferRW;
 
+var bufferAlloc = Buffer.alloc || Buffer;
+
 var str1 = StringRW(UInt8);
 var frameRW = SeriesRW(UInt8, str1);
 var writeErrorRW = {
@@ -58,7 +60,7 @@ var expectedBuffers = [];
 ].forEach(function eachToken(token, i) {
     var frame = [0, token];
     frame[0] = byteLength(frameRW, frame);
-    var expectedBuffer = intoBuffer(frameRW, Buffer(frame[0]), frame);
+    var expectedBuffer = intoBuffer(frameRW, bufferAlloc(frame[0]), frame);
     var assertMess = util.format('got expected[%s] buffer', i);
     frames.push(frame);
     expectedBuffers.push({

--- a/test/stream/concat_read_buffer.js
+++ b/test/stream/concat_read_buffer.js
@@ -24,32 +24,35 @@ var test = require('tape');
 
 var ConcatReadBuffer = require('../../stream/concat_read_buffer');
 
+var bufferFrom = Buffer.from || Buffer;
+var bufferAlloc = Buffer.alloc || Buffer;
+
 test('ConcatReadBuffer', function t(assert) {
     var buf = ConcatReadBuffer();
     assert.equal(buf.avail(), 0, 'starts out with no avail');
     assert.equal(buf.free(), 0, 'starts out with no free');
-    assert.deepEqual(buf.shift(2), Buffer(0), 'expected empty shift at first');
+    assert.deepEqual(buf.shift(2), bufferAlloc(0), 'expected empty shift at first');
 
-    buf.push(Buffer([1, 2, 3, 4]));
+    buf.push(bufferFrom([1, 2, 3, 4]));
     assert.equal(buf.avail(), 4, 'now has 4 avail');
     assert.equal(buf.free(), 0, 'still has no free');
-    assert.deepEqual(buf.shift(2), Buffer([1, 2]), 'expected shift first two');
+    assert.deepEqual(buf.shift(2), bufferFrom([1, 2]), 'expected shift first two');
 
     buf.clear();
     assert.equal(buf.avail(), 0, 'expected now empty avail');
     assert.equal(buf.free(), 0, 'expected now empty free');
-    assert.deepEqual(buf.shift(2), Buffer(0), 'expected no shift after clear');
+    assert.deepEqual(buf.shift(2), bufferAlloc(0), 'expected no shift after clear');
 
-    buf.push(Buffer([5, 6]));
+    buf.push(bufferFrom([5, 6]));
     assert.equal(buf.avail(), 2, 'now has 2 avail');
     assert.equal(buf.free(), 0, 'still has no free');
-    buf.push(Buffer([7, 8]));
+    buf.push(bufferFrom([7, 8]));
     assert.equal(buf.avail(), 4, 'now has 4 avail');
     assert.equal(buf.free(), 0, 'still has no free');
-    assert.deepEqual(buf.shift(4), Buffer([5, 6, 7, 8]), 'expected exact shift of four');
+    assert.deepEqual(buf.shift(4), bufferFrom([5, 6, 7, 8]), 'expected exact shift of four');
     assert.equal(buf.avail(), 0, 'expected now empty avail');
     assert.equal(buf.free(), 0, 'expected now empty free');
-    assert.deepEqual(buf.shift(2), Buffer(0), 'expected no shift after drain');
+    assert.deepEqual(buf.shift(2), bufferAlloc(0), 'expected no shift after drain');
 
     assert.end();
 });

--- a/test/struct_rw.js
+++ b/test/struct_rw.js
@@ -32,6 +32,9 @@ var UInt16BE = require('../atoms').UInt16BE;
 var DoubleBE = require('../atoms').DoubleBE;
 var StringRW = require('../string_rw');
 var StructRW = require('../struct');
+
+var bufferFrom = Buffer.from || Buffer;
+
 var str1 = StringRW(UInt8);
 
 var anonLoc = StructRW({
@@ -248,7 +251,7 @@ test('StructRW: non pooled frame', testRW.cases(NonPoolFrame.rw, [
 ]));
 
 test('structrw poolreadfrom correctly allocates new obj', function t(assert) {
-    var buf = new Buffer([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
+    var buf = bufferFrom([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
     var destResult = new ReadResult(null, 0, {a: 'b'});
     NonPoolFrame.rw.poolReadFrom(destResult, buf, 0);
     assert.equal(destResult.value.constructor, NonPoolFrame);
@@ -256,7 +259,7 @@ test('structrw poolreadfrom correctly allocates new obj', function t(assert) {
 });
 
 test('structrw poolreadfrom correctly reuses obj', function t(assert) {
-    var buf = new Buffer([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
+    var buf = bufferFrom([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
     var obj = new NonPoolFrame();
     var destResult = new ReadResult(null, 0, obj);
     NonPoolFrame.rw.poolReadFrom(destResult, buf, 0);

--- a/test/variable_buffer_rw.js
+++ b/test/variable_buffer_rw.js
@@ -23,6 +23,8 @@
 var testRW = require('../test_rw');
 var test = require('tape');
 
+var bufferFrom = Buffer.from || Buffer;
+
 var BufferRW = require('../base').BufferRW;
 var brokenRW = {
     poolByteLength: function(destResult) {
@@ -50,8 +52,9 @@ var normalTestCases = [
         lengthTest: {length: 1, value: null},
         writeTest: {bytes: [0x00], value: null}
     },
-    [ Buffer([0x00, 0x88, 0xff]),
-      [0x03, 0x00, 0x88, 0xff]
+    [
+        bufferFrom([0x00, 0x88, 0xff]),
+        [0x03, 0x00, 0x88, 0xff]
     ],
 
     // invalid value length/write errors
@@ -98,11 +101,11 @@ test('VariableBufferRW: lazy buf~1',
 var brokenTestCases = [
     {
         lengthTest: {
-            value: Buffer([2]),
+            value: bufferFrom([2]),
             error: {message: 'boom'}
         },
         writeTest: {
-            value: Buffer([2]),
+            value: bufferFrom([2]),
             length: 2,
             error: {message: 'bang'}
         },

--- a/test_rw.js
+++ b/test_rw.js
@@ -27,6 +27,12 @@ var formatError = require('./interface').formatError;
 var intoBufferResult = require('./interface').intoBufferResult;
 var fromBufferResult = require('./interface').fromBufferResult;
 
+// Node.js deprecated Buffer(length) in favor of Buffer.alloc(length).
+// istanbul ignore next
+var bufferFrom = Buffer.from || Buffer;
+// istanbul ignore next
+var bufferAlloc = Buffer.alloc || Buffer;
+
 module.exports.cases = testCases;
 
 function testCases(rw, cases) {
@@ -98,7 +104,7 @@ RWTestCase.prototype.runLengthTest = function runLengthTest() {
 RWTestCase.prototype.runWriteTest = function runWriteTest() {
     var testCase = this.testCase.writeTest;
     var val = testCase.value;
-    var got = Buffer(testCase.bytes ? testCase.bytes.length : testCase.length || 0);
+    var got = bufferAlloc(testCase.bytes ? testCase.bytes.length : testCase.length || 0);
     got.fill(0);
     var res = intoBufferResult(this.rw, got, val);
     var err = res.err;
@@ -117,7 +123,7 @@ RWTestCase.prototype.runWriteTest = function runWriteTest() {
         this.assert.fail('expected write error');
     } else {
         var desc = util.format('write: %j', val);
-        var buf = Buffer(testCase.bytes);
+        var buf = bufferFrom(testCase.bytes);
         // istanbul ignore if
         if (got.toString('hex') !== buf.toString('hex')) {
             // TODO: re-run write with an annotated buffer
@@ -132,7 +138,7 @@ RWTestCase.prototype.runWriteTest = function runWriteTest() {
 
 RWTestCase.prototype.runReadTest = function runReadTest() {
     var testCase = this.testCase.readTest;
-    var buffer = Buffer(testCase.bytes);
+    var buffer = bufferFrom(testCase.bytes);
     var res = fromBufferResult(this.rw, buffer);
     var err = res.err;
     var got = res.value;

--- a/variable_buffer_rw.js
+++ b/variable_buffer_rw.js
@@ -26,6 +26,10 @@ var ReadResult = require('./base').ReadResult;
 var BufferRW = require('./base').BufferRW;
 var errors = require('./errors');
 
+// Node.js deprecated Buffer(length) in favor of Buffer.alloc(length).
+// istanbul ignore next
+var bufferAlloc = Buffer.alloc || Buffer;
+
 function VariableBufferRW(sizerw, lazy) {
     if (!(this instanceof VariableBufferRW)) {
         return new VariableBufferRW(sizerw, lazy);
@@ -78,7 +82,7 @@ VariableBufferRW.prototype.eagerPoolReadFrom = function eagerPoolReadFrom(destRe
         return ReadResult.poolShortError(destResult, length, remain, offset, destResult.offset);
     } else {
         offset = destResult.offset;
-        var buf = Buffer(length);
+        var buf = bufferAlloc(length);
         buffer.copy(buf, 0, offset);
         return destResult.reset(null, offset + length, buf);
     }


### PR DESCRIPTION
Node.js deprecated new Buffer(length) and new Buffer(array) in favor of
separate Buffer.alloc and Buffer.from functions.

These changes permit bufrw to be used with Node.js as new as 12 and as old as
0.10.