### PR TITLE
Fixed FusionJS issue 622 by using ansi-colors instead of ansi-color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ coverage/
 ehthumbs.db
 Icon?
 Thumbs.db
+package-lock.json

--- a/annotated_buffer.js
+++ b/annotated_buffer.js
@@ -22,7 +22,8 @@
 
 var hex = require('hexer');
 
-var color = require('ansi-color').set;
+var color = require('ansi-colors');
+var getAnsiColor = require('./lib/get_ansi_color.js');
 var stripColor = require('./lib/strip_color.js');
 var extend = require('xtend');
 var inspect = require('util').inspect;
@@ -305,7 +306,10 @@ AnnotatedBuffer.prototype.hexdump = function hexdump(options) {
                 desc += '(' + inspect(part.value) + ')';
             }
             if (part.color) {
-                desc = color(desc, part.color);
+                // split errorColor on + and . for backwards compatibility
+                var ansiColor = getAnsiColor(part.color);
+
+                desc = ansiColor(desc);
             } else if (part.start === part.end) {
                 desc += '@' + part.start.toString(16);
             } else {
@@ -330,8 +334,8 @@ AnnotatedBuffer.prototype.hexdump = function hexdump(options) {
             i >= ann.start &&
             i < ann.end) {
             str = stripColor(str);
-            str = color(str, colors[colorI]);
-            if (i === ann.start && options.boldStart) str = color(str, 'bold');
+            str = color[colors[colorI]](str);
+            if (i === ann.start && options.boldStart) str = color.bold(str);
         }
 
         if (options.highlight) {

--- a/error_highlighter.js
+++ b/error_highlighter.js
@@ -20,7 +20,8 @@
 
 'use strict';
 
-var color = require('ansi-color').set;
+var color = require('ansi-colors');
+var getAnsiColor = require('./lib/get_ansi_color');
 var stripColor = require('./lib/strip_color.js');
 
 module.exports = errorHighlighter;
@@ -28,7 +29,15 @@ module.exports = errorHighlighter;
 // istanbul ignore next
 function errorHighlighter(err, options) {
     options = options || {};
-    var errColor = colorer(options.errorColor || 'red+bold');
+
+    // split errorColor on + and . for backwards compatibility
+    var ansiColor = getAnsiColor(options.errorColor);
+    if(ansiColor === color) {
+        ansiColor = color.red.bold;
+    }
+
+    var errColor = colorer(ansiColor);
+    console.log(errColor);
 
     var hasOffset = !(err.offset === undefined || err.offset === null);
     var hasEnd = !(err.endOffset === undefined || err.endOffset === null);
@@ -68,6 +77,7 @@ function errorHighlighter(err, options) {
 function colorer(col) {
     if (typeof col === 'function') return col;
     return function colorIt(str) {
-        return color(str, col);
+        console.log(col);
+        return col(str);
     };
 }

--- a/lib/get_ansi_color.js
+++ b/lib/get_ansi_color.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var color = require('ansi-colors');
+
+module.exports = getAnsiColor;
+
+// istanbul ignore next
+function getAnsiColor(colorStr) {
+  // split errorColor on + and . for backwards compatibility
+  var colorAttrs = (colorStr || '')
+    .split(/[\+\.]/)
+    .filter(function (c) { return c; });
+
+  var ansiColor = color;
+
+  for(var i=0; i < colorAttrs.length; i++) {
+    // deal with color_bg values
+    var bgIndex = colorAttrs[i].indexOf('_bg');
+    if (bgIndex > -1) {
+      var colorName = colorAttrs[i].substring(0, bgIndex);
+      colorName = colorName.replace(/^\w/, function (c) {
+        return c.toUpperCase();
+      });
+      colorAttrs[i] = 'bg'+colorName;
+    }
+
+    ansiColor = ansiColor[colorAttrs[i]];
+    console.log(colorAttrs[i], ansiColor);
+  }
+
+  return ansiColor;
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "ansi-color": "^0.2.1",
+    "ansi-colors": "^4.1.1",
     "error": "^7.0.0",
     "hexer": "^1.5.0",
     "xtend": "^4.0.0"

--- a/test/test_rw.js
+++ b/test/test_rw.js
@@ -81,7 +81,6 @@ test('testRW: unexpected errors', function t(assert) {
 
         assert.equal(results[4].name, 'no read error', 'expected "no read error"');
         assert.equal(results[4].actual.message, 'bork', 'expected actual "bork" error');
-
         assert.equal(results[5],
             'read error Error: bork');
 


### PR DESCRIPTION
Related: 
  fusionjs/fusion-cli#622
  https://github.com/jcorbin/hexer/pull/17

ansi-color uses octal notation for colors that seems to cause errors when using Babel's es2015 preset which uses strict mode for Javascript. This strict mode doesn't allow hex codes starting with `\0xy`, it must start with `\u0xy` instead. Instead of attempting to fix very old code within ansi-color, I have changed the package dependency to use a better supported utility called ansi-colors.

While making this decision to use ansi-colors, we also could have used chalk. Both are well used and supported, but ansi-colors was a better near drop-in replacement to ansi-color. This change makes the external contract the same, so users of hexer will notice no difference and won't need to change their code at all besides the package version.

It's entirely possible to create a patch or minor version update since this is an internal change that doesn't affect external code.