### PR TITLE
Refactor away from deprecated Buffer constructor usage

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -133,8 +133,7 @@ function toBufferResult(rw, value) {
     var lenRes = rw.byteLength(value);
     if (lenRes.err) return new Result(lenRes.err, emptyBuffer);
     var length = lenRes.length;
-    var buffer = new Buffer(length);
-    // buffer.fill(0); TODO option
+    var buffer = Buffer.alloc(length);
     return intoBufferResult(rw, buffer, value);
 }
 

--- a/test/repeat_rw.js
+++ b/test/repeat_rw.js
@@ -124,7 +124,7 @@ test('RepeatRW: passes partrw error thru', testRW.cases(RepeatRW(atoms.UInt8, br
 
 test('RepeatRW: properly handles repeated array rws', function t(assert) {
     var thing = RepeatRW(atoms.UInt8, SeriesRW(atoms.UInt8, atoms.UInt8));
-    var buf = new Buffer([0x01, 0x02, 0x03]);
+    var buf = Buffer.from([0x01, 0x02, 0x03]);
 
     var readResult = new ReadResult();
     thing.poolReadFrom(readResult, buf, 0);
@@ -150,7 +150,7 @@ var consLoc = StructRW(Loc, {
 
 test('RepeatRW: properly handles repeated object rws', function t(assert) {
     var thing = RepeatRW(atoms.UInt8, consLoc);
-    var buf = new Buffer([0x01, 0x40, 0x42, 0xe3, 0x43, 0x7c, 0x56, 0x92, 0xb4,
+    var buf = Buffer.from([0x01, 0x40, 0x42, 0xe3, 0x43, 0x7c, 0x56, 0x92, 0xb4,
       0xc0, 0x5e, 0x9a, 0xb8, 0xa1, 0x9c, 0x9d, 0x5a]);
 
     var readResult = new ReadResult();

--- a/test/struct_rw.js
+++ b/test/struct_rw.js
@@ -248,7 +248,7 @@ test('StructRW: non pooled frame', testRW.cases(NonPoolFrame.rw, [
 ]));
 
 test('structrw poolreadfrom correctly allocates new obj', function t(assert) {
-    var buf = new Buffer([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
+    var buf = Buffer.from([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
     var destResult = new ReadResult(null, 0, {a: 'b'});
     NonPoolFrame.rw.poolReadFrom(destResult, buf, 0);
     assert.equal(destResult.value.constructor, NonPoolFrame);
@@ -256,7 +256,7 @@ test('structrw poolreadfrom correctly allocates new obj', function t(assert) {
 });
 
 test('structrw poolreadfrom correctly reuses obj', function t(assert) {
-    var buf = new Buffer([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
+    var buf = Buffer.from([0x00, 0x06, 0x03, 0x63, 0x61, 0x74]);
     var obj = new NonPoolFrame();
     var destResult = new ReadResult(null, 0, obj);
     NonPoolFrame.rw.poolReadFrom(destResult, buf, 0);


### PR DESCRIPTION
Buffer constructor API has been long deprecated due to security concerns. In latest versions of node.js it also emits a warning, which sometimes comes with a performance hit due to [stack computation](https://github.com/nodejs/node/blob/6431c657d9dd8b75ea71956461870be7ba9d89b8/lib/buffer.js#L183) that's happening in node.js core, which can be happening on a critical path and degrade the overall performance of the application. Refactoring current usages of Buffer in this package to use newer and stable APIs: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation