### PR TITLE
Remove deprecated Buffer API usages

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -51,7 +51,7 @@ function annotateError(res1, res2, start, annBuf) {
     }
 }
 
-var emptyBuffer = Buffer(0);
+var emptyBuffer = Buffer.alloc(0);
 
 function fromBuffer(rw, buffer, offset) {
     return fromBufferResult(rw, buffer, offset).toValue();

--- a/stream/concat_read_buffer.js
+++ b/stream/concat_read_buffer.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var emptyBuffer = Buffer(0);
+var emptyBuffer = Buffer.alloc(0);
 
 function ConcatReadBuffer() {
     if (!(this instanceof ConcatReadBuffer)) {

--- a/test/fixed_width_rw.js
+++ b/test/fixed_width_rw.js
@@ -28,12 +28,12 @@ var FixedWidthRW = require('../fixed_width_rw');
 var fix8 = FixedWidthRW(8);
 var fixed8 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
 test('FixedWidthRW: simple fix:8', testRW.cases(fix8, [
-    [Buffer(fixed8), fixed8],
+    [Buffer.from(fixed8), fixed8],
 
     // mismatch errors
     {
         lengthTest: {
-            value: Buffer([0x01]),
+            value: Buffer.from([0x01]),
             error: {
                 type: 'bufrw.fixed-length-mismatch',
                 message: 'supplied length 1 mismatches fixed length 8',
@@ -42,7 +42,7 @@ test('FixedWidthRW: simple fix:8', testRW.cases(fix8, [
             }
         },
         writeTest: {
-            value: Buffer([0x01]),
+            value: Buffer.from([0x01]),
             error: {
                 type: 'bufrw.fixed-length-mismatch',
                 message: 'supplied length 1 mismatches fixed length 8',

--- a/test/interface.js
+++ b/test/interface.js
@@ -71,7 +71,7 @@ test('byteLength', function t(assert) {
 test('toBuffer', function t(assert) {
     assert.deepEqual(
         iface.toBuffer(byteRW, 1),
-        Buffer([0x01]), 'write 1 uint8');
+        Buffer.from([0x01]), 'write 1 uint8');
     assert.throws(function() {
         iface.toBuffer(lengthErrorRW, 1);
     }, /boom/, 'length error throws');
@@ -83,26 +83,26 @@ test('toBuffer', function t(assert) {
 
 test('intoBuffer', function t(assert) {
     assert.deepEqual(
-        iface.intoBuffer(byteRW, Buffer([0]), 1),
-        Buffer([0x01]), 'write 1 uint8');
+        iface.intoBuffer(byteRW, Buffer.from([0]), 1),
+        Buffer.from([0x01]), 'write 1 uint8');
     assert.throws(function() {
-        iface.intoBuffer(writeErrorRW, Buffer([0]), 1);
+        iface.intoBuffer(writeErrorRW, Buffer.from([0]), 1);
     }, /bang/, 'write error throws');
     assert.throws(function() {
-        iface.intoBuffer(byteRW, Buffer([0, 0]), 1);
+        iface.intoBuffer(byteRW, Buffer.from([0, 0]), 1);
     }, /short write, 1 byte left over after writing 1/, 'short write error');
     assert.end();
 });
 
 test('fromBuffer', function t(assert) {
     assert.equal(
-        iface.fromBuffer(byteRW, Buffer([0x01])),
+        iface.fromBuffer(byteRW, Buffer.from([0x01])),
         1, 'read 1 uint8');
     assert.throws(function() {
-        iface.fromBuffer(readErrorRW, Buffer(0));
+        iface.fromBuffer(readErrorRW, Buffer.alloc(0));
     }, /zot/, 'read error throws');
     assert.throws(function() {
-        iface.fromBuffer(byteRW, Buffer([0, 0]));
+        iface.fromBuffer(byteRW, Buffer.from([0, 0]));
     }, /short read, 1 byte left over after consuming 1/, 'short read error');
     assert.end();
 });

--- a/test/stream/chunk_reader.js
+++ b/test/stream/chunk_reader.js
@@ -54,7 +54,7 @@ var expectedFrames = [];
 ].forEach(function eachToken(token, i) {
     var frame = [0, token];
     frame[0] = byteLength(frameRW, frame);
-    var buf = intoBuffer(frameRW, Buffer(frame[0]), frame);
+    var buf = intoBuffer(frameRW, Buffer.alloc(frame[0]), frame);
     buffers.push(buf);
     var assertMess = util.format('got expected[%s] payload token %j', i, token);
     expectedFrames.push({frame: expectToken});
@@ -67,7 +67,7 @@ var BigChunk = Buffer.concat(buffers);
 
 var oneBytePer = new Array(BigChunk.length);
 for (var i = 0; i < BigChunk.length; i++) {
-    oneBytePer.push(Buffer([BigChunk[i]]));
+    oneBytePer.push(Buffer.from([BigChunk[i]]));
 }
 
 readerTest('works frame-at-a-time', frameRW, buffers, expectedFrames);
@@ -96,7 +96,7 @@ function readerTest(desc, frameRW, chunks, expected) {
 }
 
 readerTest('recognizes zero-sized chunks with an error', frameRW, [
-    Buffer([0x00])
+    Buffer.from([0x00])
 ], [
     {
         error: function(err, assert) {
@@ -111,7 +111,7 @@ readerTest('recognizes zero-sized chunks with an error', frameRW, [
 ]);
 
 readerTest('handles sizeRW errors', SeriesRW(readErrorRW, str1), [
-    Buffer([0x01])
+    Buffer.from([0x01])
 ], [
     {
         error: function(err, assert) {
@@ -121,7 +121,7 @@ readerTest('handles sizeRW errors', SeriesRW(readErrorRW, str1), [
 ]);
 
 readerTest('handles chunkRW errors', SeriesRW(UInt8, readErrorRW), [
-    Buffer([0x02, 0x00])
+    Buffer.from([0x02, 0x00])
 ], [
     {
         error: function(err, assert) {
@@ -131,7 +131,7 @@ readerTest('handles chunkRW errors', SeriesRW(UInt8, readErrorRW), [
 ]);
 
 readerTest('errors on truncated frame', frameRW, [
-    Buffer([0x02, 0x01, 0x05])
+    Buffer.from([0x02, 0x01, 0x05])
 ], [
     {
         error: function(err, assert) {
@@ -143,7 +143,7 @@ readerTest('errors on truncated frame', frameRW, [
                 expected: 1,
                 actual: 0,
                 buffer: {
-                    buffer: Buffer([2, 1]),
+                    buffer: Buffer.from([2, 1]),
                     annotations: [
                         { kind: 'read', name: 'UInt8', start: 0, end: 1, value: 2 },
                         { kind: 'read', name: 'UInt8', start: 1, end: 2, value: 1 }

--- a/test/stream/chunk_writer.js
+++ b/test/stream/chunk_writer.js
@@ -58,7 +58,7 @@ var expectedBuffers = [];
 ].forEach(function eachToken(token, i) {
     var frame = [0, token];
     frame[0] = byteLength(frameRW, frame);
-    var expectedBuffer = intoBuffer(frameRW, Buffer(frame[0]), frame);
+    var expectedBuffer = intoBuffer(frameRW, Buffer.alloc(frame[0]), frame);
     var assertMess = util.format('got expected[%s] buffer', i);
     frames.push(frame);
     expectedBuffers.push({

--- a/test/stream/concat_read_buffer.js
+++ b/test/stream/concat_read_buffer.js
@@ -28,28 +28,28 @@ test('ConcatReadBuffer', function t(assert) {
     var buf = ConcatReadBuffer();
     assert.equal(buf.avail(), 0, 'starts out with no avail');
     assert.equal(buf.free(), 0, 'starts out with no free');
-    assert.deepEqual(buf.shift(2), Buffer(0), 'expected empty shift at first');
+    assert.deepEqual(buf.shift(2), Buffer.alloc(0), 'expected empty shift at first');
 
-    buf.push(Buffer([1, 2, 3, 4]));
+    buf.push(Buffer.from([1, 2, 3, 4]));
     assert.equal(buf.avail(), 4, 'now has 4 avail');
     assert.equal(buf.free(), 0, 'still has no free');
-    assert.deepEqual(buf.shift(2), Buffer([1, 2]), 'expected shift first two');
+    assert.deepEqual(buf.shift(2), Buffer.from([1, 2]), 'expected shift first two');
 
     buf.clear();
     assert.equal(buf.avail(), 0, 'expected now empty avail');
     assert.equal(buf.free(), 0, 'expected now empty free');
-    assert.deepEqual(buf.shift(2), Buffer(0), 'expected no shift after clear');
+    assert.deepEqual(buf.shift(2), Buffer.alloc(0), 'expected no shift after clear');
 
-    buf.push(Buffer([5, 6]));
+    buf.push(Buffer.from([5, 6]));
     assert.equal(buf.avail(), 2, 'now has 2 avail');
     assert.equal(buf.free(), 0, 'still has no free');
-    buf.push(Buffer([7, 8]));
+    buf.push(Buffer.from([7, 8]));
     assert.equal(buf.avail(), 4, 'now has 4 avail');
     assert.equal(buf.free(), 0, 'still has no free');
-    assert.deepEqual(buf.shift(4), Buffer([5, 6, 7, 8]), 'expected exact shift of four');
+    assert.deepEqual(buf.shift(4), Buffer.from([5, 6, 7, 8]), 'expected exact shift of four');
     assert.equal(buf.avail(), 0, 'expected now empty avail');
     assert.equal(buf.free(), 0, 'expected now empty free');
-    assert.deepEqual(buf.shift(2), Buffer(0), 'expected no shift after drain');
+    assert.deepEqual(buf.shift(2), Buffer.alloc(0), 'expected no shift after drain');
 
     assert.end();
 });

--- a/test/variable_buffer_rw.js
+++ b/test/variable_buffer_rw.js
@@ -50,7 +50,7 @@ var normalTestCases = [
         lengthTest: {length: 1, value: null},
         writeTest: {bytes: [0x00], value: null}
     },
-    [ Buffer([0x00, 0x88, 0xff]),
+    [ Buffer.from([0x00, 0x88, 0xff]),
       [0x03, 0x00, 0x88, 0xff]
     ],
 
@@ -98,11 +98,11 @@ test('VariableBufferRW: lazy buf~1',
 var brokenTestCases = [
     {
         lengthTest: {
-            value: Buffer([2]),
+            value: Buffer.from([2]),
             error: {message: 'boom'}
         },
         writeTest: {
-            value: Buffer([2]),
+            value: Buffer.from([2]),
             length: 2,
             error: {message: 'bang'}
         },

--- a/test_rw.js
+++ b/test_rw.js
@@ -98,8 +98,7 @@ RWTestCase.prototype.runLengthTest = function runLengthTest() {
 RWTestCase.prototype.runWriteTest = function runWriteTest() {
     var testCase = this.testCase.writeTest;
     var val = testCase.value;
-    var got = Buffer(testCase.bytes ? testCase.bytes.length : testCase.length || 0);
-    got.fill(0);
+    var got = Buffer.alloc(testCase.bytes ? testCase.bytes.length : testCase.length || 0);
     var res = intoBufferResult(this.rw, got, val);
     var err = res.err;
 
@@ -117,7 +116,7 @@ RWTestCase.prototype.runWriteTest = function runWriteTest() {
         this.assert.fail('expected write error');
     } else {
         var desc = util.format('write: %j', val);
-        var buf = Buffer(testCase.bytes);
+        var buf = Buffer.from(testCase.bytes);
         // istanbul ignore if
         if (got.toString('hex') !== buf.toString('hex')) {
             // TODO: re-run write with an annotated buffer
@@ -132,7 +131,7 @@ RWTestCase.prototype.runWriteTest = function runWriteTest() {
 
 RWTestCase.prototype.runReadTest = function runReadTest() {
     var testCase = this.testCase.readTest;
-    var buffer = Buffer(testCase.bytes);
+    var buffer = Buffer.from(testCase.bytes);
     var res = fromBufferResult(this.rw, buffer);
     var err = res.err;
     var got = res.value;

--- a/variable_buffer_rw.js
+++ b/variable_buffer_rw.js
@@ -78,7 +78,7 @@ VariableBufferRW.prototype.eagerPoolReadFrom = function eagerPoolReadFrom(destRe
         return ReadResult.poolShortError(destResult, length, remain, offset, destResult.offset);
     } else {
         offset = destResult.offset;
-        var buf = Buffer(length);
+        var buf = Buffer.alloc(length);
         buffer.copy(buf, 0, offset);
         return destResult.reset(null, offset + length, buf);
     }


### PR DESCRIPTION
A follow-up on https://github.com/uber/bufrw/pull/71 which removes remaining deprecated Buffer API usages 